### PR TITLE
lowered target Android version to 4.4

### DIFF
--- a/BottomSheet-Xamarin.Android/BottomSheet-Xamarin.Android.csproj
+++ b/BottomSheet-Xamarin.Android/BottomSheet-Xamarin.Android.csproj
@@ -12,8 +12,7 @@
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <AssemblyName>Cocosw.BottomSheet-Xamarin.Android</AssemblyName>
     <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
+    <ReleaseVersion>1.1.0.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -40,7 +39,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
     <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>..\..\..\Users\dave\Projects\WhitePaperBible\packages\Xamarin.Android.Support.v4.22.2.1.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v4.23.0.1.1\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/BottomSheet-Xamarin.Android/BottomSheet-Xamarin.Android.csproj
+++ b/BottomSheet-Xamarin.Android/BottomSheet-Xamarin.Android.csproj
@@ -9,10 +9,11 @@
     <RootNamespace>Cocosw.BottomSheetActions</RootNamespace>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <AssemblyName>Cocosw.BottomSheet-Xamarin.Android</AssemblyName>
-    <TargetFrameworkVersion>v5.1</TargetFrameworkVersion>
-    <ReleaseVersion>1.1.0.0</ReleaseVersion>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,7 +40,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
     <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>..\packages\Xamarin.Android.Support.v4.22.2.1.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+      <HintPath>..\..\..\Users\dave\Projects\WhitePaperBible\packages\Xamarin.Android.Support.v4.22.2.1.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/BottomSheet-Xamarin.Android/packages.config
+++ b/BottomSheet-Xamarin.Android/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Android.Support.v4" version="22.2.1.0" targetFramework="MonoAndroid51" />
+  <package id="Xamarin.Android.Support.v4" version="22.2.1.0" targetFramework="MonoAndroid44" />
 </packages>

--- a/BottomSheet-Xamarin.Android/packages.config
+++ b/BottomSheet-Xamarin.Android/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Android.Support.v4" version="22.2.1.0" targetFramework="MonoAndroid44" />
+  <package id="Xamarin.Android.Support.v4" version="23.0.1.1" targetFramework="MonoAndroid44" />
 </packages>


### PR DESCRIPTION
Thanks for making this binding! What do you think about dropping the target Android to 4.4 instead of latest? It seems to work just fine, and when targeting latest we end up getting AppCompat runtime errors.
